### PR TITLE
FIX: fcgi caching configuration

### DIFF
--- a/etc/nginx/nginx.conf
+++ b/etc/nginx/nginx.conf
@@ -3,31 +3,31 @@ worker_processes        4;
 pid                     /run/nginx.pid;
 
 events {
-	worker_connections    1024;
+  worker_connections    1024;
 }
 
 http {
-	sendfile              on;
-	sendfile_max_chunk    512k;
-	tcp_nopush            on;
-	tcp_nodelay           on;
-	keepalive_timeout     65;
-	types_hash_max_size   2048;
+  sendfile              on;
+  sendfile_max_chunk    512k;
+  tcp_nopush            on;
+  tcp_nodelay           on;
+  keepalive_timeout     65;
+  types_hash_max_size   2048;
 
-	include               /etc/nginx/mime.types;
-	default_type          application/octet-stream;
+  include               /etc/nginx/mime.types;
+  default_type          application/octet-stream;
 
-	log_format cache_status '$remote_addr - $upstream_cache_status [$time_local]  '
-													'"$request" $status $body_bytes_sent '
-													'"$http_referer" "$http_user_agent"';
+  log_format cache_status '$remote_addr - $upstream_cache_status [$time_local]  '
+                          '"$request" $status $body_bytes_sent '
+                          '"$http_referer" "$http_user_agent"';
 
-	access_log            /dev/stdout cache_status;
-	error_log             /dev/stdout info;
+  access_log            /dev/stdout cache_status;
+  error_log             /dev/stdout info;
 
-	gzip                  on;
-	gzip_disable          "msie6";
+  gzip                  on;
+  gzip_disable          "msie6";
 
-	include               /etc/nginx/sites-enabled/*;
+  include               /etc/nginx/sites-enabled/*;
 }
 
 

--- a/etc/nginx/nginx.conf
+++ b/etc/nginx/nginx.conf
@@ -17,8 +17,12 @@ http {
 	include               /etc/nginx/mime.types;
 	default_type          application/octet-stream;
 
-	access_log            /var/log/nginx/access.log;
-	error_log             /var/log/nginx/error.log;
+	log_format cache_status '$remote_addr - $upstream_cache_status [$time_local]  '
+													'"$request" $status $body_bytes_sent '
+													'"$http_referer" "$http_user_agent"';
+
+	access_log            /dev/stdout cache_status;
+	error_log             /dev/stdout info;
 
 	gzip                  on;
 	gzip_disable          "msie6";

--- a/etc/nginx/nginx.conf
+++ b/etc/nginx/nginx.conf
@@ -8,6 +8,7 @@ events {
 
 http {
 	sendfile              on;
+	sendfile_max_chunk    512k;
 	tcp_nopush            on;
 	tcp_nodelay           on;
 	keepalive_timeout     65;

--- a/etc/nginx/sites-enabled/git-http
+++ b/etc/nginx/sites-enabled/git-http
@@ -1,36 +1,43 @@
 fastcgi_cache_path /etc/nginx/cache levels=1:2 keys_zone=gitserver_http:800m inactive=30m;
-fastcgi_cache_key "$scheme$request_method$host$request_uri";
+fastcgi_cache_key "$scheme$request_method$host$request_uri|$request_body";
 
 server {
 	server_name       _;
 	listen 80         default_server;
 	listen [::]:80    default_server;
 
-  location /ping {
-      add_header Content-Type text/plain;
-      return 200 'pong';
-  }
+	location /status {
+		add_header Content-Type text/plain;
+		return 200 'ok';
+	}
 
-  location ~ ^.*\.git/objects/([0-9a-f]+/[0-9a-f]+|pack/pack-[0-9a-f]+.(pack|idx))$ {
-    root                /var/lib/git;
-    fastcgi_cache       gitserver_http:
-    fastcgi_cache_valid 1m
-  }
+	location ~ ^.*\.git/objects/([0-9a-f]+/[0-9a-f]+|pack/pack-[0-9a-f]+.(pack|idx))$ {
+		root                    /var/lib/git;
+		fastcgi_cache           gitserver_http;
+		fastcgi_cache_methods   GET HEAD POST;
+		fastcgi_cache_use_stale updating error timeout;
+		fastcgi_cache_lock      on;
+		fastcgi_cache_valid     200 3m;
+		fastcgi_ignore_headers  Cache-Control Expires Set-Cookie;
+	}
 
-  location ~ ^.*\.git/(HEAD|info/refs|objects/info/.*|git-(upload|receive)-pack)$ {
-    include             fastcgi_params;
-    fastcgi_param       SCRIPT_FILENAME /usr/libexec/git-core/git-http-backend;
-    fastcgi_param       GIT_HTTP_EXPORT_ALL "";
-    fastcgi_param       GIT_PROJECT_ROOT /var/lib/git;
-    fastcgi_param       PATH_INFO $uri;
-    fastcgi_param       REMOTE_USER $remote_user;
-    fastcgi_pass        unix:/var/run/fcgiwrap.socket;
-    fastcgi_cache       gitserver_http:
-    fastcgi_cache_valid 1m
-  }
+	location ~ ^.*\.git/(HEAD|info/refs|objects/info/.*|git-(upload|receive)-pack)$ {
+		include                 fastcgi_params;
+		fastcgi_param           SCRIPT_FILENAME /usr/libexec/git-core/git-http-backend;
+		fastcgi_param           GIT_HTTP_EXPORT_ALL "";
+		fastcgi_param           GIT_PROJECT_ROOT /var/lib/git;
+		fastcgi_param           PATH_INFO $uri;
+		fastcgi_param           REMOTE_USER $remote_user;
+		fastcgi_pass            unix:/var/run/fcgiwrap.socket;
+		fastcgi_cache           gitserver_http;
+		fastcgi_cache_methods   GET HEAD POST;
+		fastcgi_cache_use_stale updating error timeout;
+		fastcgi_cache_lock      on;
+		fastcgi_cache_valid     200 3m;
+		fastcgi_ignore_headers  Cache-Control Expires Set-Cookie;
+	}
 
 	location / {
 		try_files       $uri $uri/ =404;
 	}
 }
-

--- a/etc/nginx/sites-enabled/git-http
+++ b/etc/nginx/sites-enabled/git-http
@@ -2,42 +2,42 @@ fastcgi_cache_path /etc/nginx/cache levels=1:2 keys_zone=gitserver_http:800m ina
 fastcgi_cache_key "$scheme$request_method$host$request_uri|$request_body";
 
 server {
-	server_name       _;
-	listen 80         default_server;
-	listen [::]:80    default_server;
+  server_name       _;
+  listen 80         default_server;
+  listen [::]:80    default_server;
 
-	location /status {
-		add_header Content-Type text/plain;
-		return 200 'ok';
-	}
+  location /status {
+    add_header Content-Type text/plain;
+    return 200 'ok';
+  }
 
-	location ~ ^.*\.git/objects/([0-9a-f]+/[0-9a-f]+|pack/pack-[0-9a-f]+.(pack|idx))$ {
-		root                    /var/lib/git;
-		fastcgi_cache           gitserver_http;
-		fastcgi_cache_methods   GET HEAD POST;
-		fastcgi_cache_use_stale updating error timeout;
-		fastcgi_cache_lock      on;
-		fastcgi_cache_valid     200 3m;
-		fastcgi_ignore_headers  Cache-Control Expires Set-Cookie;
-	}
+  location ~ ^.*\.git/objects/([0-9a-f]+/[0-9a-f]+|pack/pack-[0-9a-f]+.(pack|idx))$ {
+    root                    /var/lib/git;
+    fastcgi_cache           gitserver_http;
+    fastcgi_cache_methods   GET HEAD POST;
+    fastcgi_cache_use_stale updating error timeout;
+    fastcgi_cache_lock      on;
+    fastcgi_cache_valid     200 3m;
+    fastcgi_ignore_headers  Cache-Control Expires Set-Cookie;
+  }
 
-	location ~ ^.*\.git/(HEAD|info/refs|objects/info/.*|git-(upload|receive)-pack)$ {
-		include                 fastcgi_params;
-		fastcgi_param           SCRIPT_FILENAME /usr/libexec/git-core/git-http-backend;
-		fastcgi_param           GIT_HTTP_EXPORT_ALL "";
-		fastcgi_param           GIT_PROJECT_ROOT /var/lib/git;
-		fastcgi_param           PATH_INFO $uri;
-		fastcgi_param           REMOTE_USER $remote_user;
-		fastcgi_pass            unix:/var/run/fcgiwrap.socket;
-		fastcgi_cache           gitserver_http;
-		fastcgi_cache_methods   GET HEAD POST;
-		fastcgi_cache_use_stale updating error timeout;
-		fastcgi_cache_lock      on;
-		fastcgi_cache_valid     200 3m;
-		fastcgi_ignore_headers  Cache-Control Expires Set-Cookie;
-	}
+  location ~ ^.*\.git/(HEAD|info/refs|objects/info/.*|git-(upload|receive)-pack)$ {
+    include                 fastcgi_params;
+    fastcgi_param           SCRIPT_FILENAME /usr/libexec/git-core/git-http-backend;
+    fastcgi_param           GIT_HTTP_EXPORT_ALL "";
+    fastcgi_param           GIT_PROJECT_ROOT /var/lib/git;
+    fastcgi_param           PATH_INFO $uri;
+    fastcgi_param           REMOTE_USER $remote_user;
+    fastcgi_pass            unix:/var/run/fcgiwrap.socket;
+    fastcgi_cache           gitserver_http;
+    fastcgi_cache_methods   GET HEAD POST;
+    fastcgi_cache_use_stale updating error timeout;
+    fastcgi_cache_lock      on;
+    fastcgi_cache_valid     200 3m;
+    fastcgi_ignore_headers  Cache-Control Expires Set-Cookie;
+  }
 
-	location / {
-		try_files       $uri $uri/ =404;
-	}
+  location / {
+    try_files       $uri $uri/ =404;
+  }
 }


### PR DESCRIPTION
- Syntax error in `fastcgi_cache` line
- caching of POST requests
- considering the request body in the cache key

Ref #spdo-203

---

# WHY?

For anyone stumbling across this and our reasons for caching git-http server.

From the official Git protocol description: https://github.com/git/git/blob/master/Documentation/technical/http-protocol.txt

> Clients MUST NOT reuse or revalidate a cached response. Servers MUST include sufficient Cache-Control headers to prevent caching of the response.

I think they make some very reasonable assumptions that don't apply to us. 

* They assume all parties are actually making commits - we only have one party making commits - linearly, on master.
* They assume that POST requests are not cached and the response is not based on the post body.
* They assume that the same exact same POST request is made close to just once. In our case of common.js - we'll get 30k-40k identical POST requests as a part of our clients' pull requests.

In our testing, we've successfully tested this caching of the git repo on our Nginx proxy for our use case.