### PR TITLE
Enh/improve git nginx caching

### DIFF
--- a/etc/nginx/sites-enabled/git-http
+++ b/etc/nginx/sites-enabled/git-http
@@ -1,5 +1,5 @@
-fastcgi_cache_path /etc/nginx/cache-get levels=1:2 keys_zone=gitserver_http_get:200m inactive=30m;
-fastcgi_cache_path /etc/nginx/cache-post levels=1:2 keys_zone=gitserver_http_post:2048m inactive=30m;
+fastcgi_cache_path /etc/nginx/cache-get levels=1:2 keys_zone=gitserver_http_get:200m inactive=2h;
+fastcgi_cache_path /etc/nginx/cache-post levels=1:2 keys_zone=gitserver_http_post:2048m inactive=2h;
 fastcgi_cache_key "$scheme$request_method$host$request_uri|$request_body";
 
 server {

--- a/etc/nginx/sites-enabled/git-http
+++ b/etc/nginx/sites-enabled/git-http
@@ -21,7 +21,7 @@ server {
     fastcgi_ignore_headers  Cache-Control Expires Set-Cookie;
   }
 
-  location ~ ^.*\.git/(HEAD|info/refs|objects/info/.*|git-(upload|receive)-pack)$ {
+  location ~ ^.*\.git/(info/refs|objects/info/.*|git-(upload|receive)-pack)$ {
     include                 fastcgi_params;
     fastcgi_param           SCRIPT_FILENAME /usr/libexec/git-core/git-http-backend;
     fastcgi_param           GIT_HTTP_EXPORT_ALL "";

--- a/etc/nginx/sites-enabled/git-http
+++ b/etc/nginx/sites-enabled/git-http
@@ -1,4 +1,5 @@
-fastcgi_cache_path /etc/nginx/cache levels=1:2 keys_zone=gitserver_http:800m inactive=30m;
+fastcgi_cache_path /etc/nginx/cache-get levels=1:2 keys_zone=gitserver_http_get:200m inactive=30m;
+fastcgi_cache_path /etc/nginx/cache-post levels=1:2 keys_zone=gitserver_http_post:600m inactive=30m;
 fastcgi_cache_key "$scheme$request_method$host$request_uri|$request_body";
 
 server {
@@ -11,17 +12,8 @@ server {
     return 200 'ok';
   }
 
-  location ~ ^.*\.git/objects/([0-9a-f]+/[0-9a-f]+|pack/pack-[0-9a-f]+.(pack|idx))$ {
-    root                    /var/lib/git;
-    fastcgi_cache           gitserver_http;
-    fastcgi_cache_methods   GET HEAD POST;
-    fastcgi_cache_use_stale updating error timeout;
-    fastcgi_cache_lock      on;
-    fastcgi_cache_valid     200 3m;
-    fastcgi_ignore_headers  Cache-Control Expires Set-Cookie;
-  }
-
-  location ~ ^.*\.git/(info/refs|objects/info/.*|git-(upload|receive)-pack)$ {
+  # GET and HEAD requests caching
+  location ~* ^.*\.git/info/refs.*$ {
     include                 fastcgi_params;
     fastcgi_param           SCRIPT_FILENAME /usr/libexec/git-core/git-http-backend;
     fastcgi_param           GIT_HTTP_EXPORT_ALL "";
@@ -29,11 +21,28 @@ server {
     fastcgi_param           PATH_INFO $uri;
     fastcgi_param           REMOTE_USER $remote_user;
     fastcgi_pass            unix:/var/run/fcgiwrap.socket;
-    fastcgi_cache           gitserver_http;
-    fastcgi_cache_methods   GET HEAD POST;
+    fastcgi_cache           gitserver_http_get;
+    fastcgi_cache_methods   GET HEAD;
     fastcgi_cache_use_stale updating error timeout;
     fastcgi_cache_lock      on;
     fastcgi_cache_valid     200 3m;
+    fastcgi_ignore_headers  Cache-Control Expires Set-Cookie;
+  }
+
+  # POST requests caching
+  location ~* ^.*\.git/git-upload-pack$ {
+    include                 fastcgi_params;
+    fastcgi_param           SCRIPT_FILENAME /usr/libexec/git-core/git-http-backend;
+    fastcgi_param           GIT_HTTP_EXPORT_ALL "";
+    fastcgi_param           GIT_PROJECT_ROOT /var/lib/git;
+    fastcgi_param           PATH_INFO $uri;
+    fastcgi_param           REMOTE_USER $remote_user;
+    fastcgi_pass            unix:/var/run/fcgiwrap.socket;
+    fastcgi_cache           gitserver_http_post;
+    fastcgi_cache_methods   POST;
+    fastcgi_cache_use_stale updating error timeout;
+    fastcgi_cache_lock      on;
+    fastcgi_cache_valid     200 10m;
     fastcgi_ignore_headers  Cache-Control Expires Set-Cookie;
   }
 

--- a/etc/nginx/sites-enabled/git-http
+++ b/etc/nginx/sites-enabled/git-http
@@ -1,5 +1,5 @@
 fastcgi_cache_path /etc/nginx/cache-get levels=1:2 keys_zone=gitserver_http_get:200m inactive=30m;
-fastcgi_cache_path /etc/nginx/cache-post levels=1:2 keys_zone=gitserver_http_post:600m inactive=30m;
+fastcgi_cache_path /etc/nginx/cache-post levels=1:2 keys_zone=gitserver_http_post:2048m inactive=30m;
 fastcgi_cache_key "$scheme$request_method$host$request_uri|$request_body";
 
 server {


### PR DESCRIPTION
I have an issue with caching urls with query parameters, if e.g.
`GET /manifest-prod/common.git/info/refs?service=git-upload-pack`
is cached,
`GET /manifest-prod/common.git/info/refs?service=blah-blah`
perceived as a different cache item. 
So I want to confirm that it's not the behavior we want. @Rio517 waiting for your answer here before trying to fix it.